### PR TITLE
parse and tryparse handling Nothing and Missing

### DIFF
--- a/base/parse.jl
+++ b/base/parse.jl
@@ -380,6 +380,8 @@ parse(::Type{T}, s::AbstractString; kwargs...) where T<:Real =
     convert(T, tryparse_internal(T, s, true; kwargs...))
 parse(::Type{T}, s::AbstractString) where T<:Complex =
     convert(T, tryparse_internal(T, s, firstindex(s), lastindex(s), true))
+parse(::Type{T}, s::Union{Missing, Nothing}) where T<:Number = s
 
 tryparse(T::Type{Complex{S}}, s::AbstractString) where S<:Real =
     tryparse_internal(T, s, firstindex(s), lastindex(s), false)
+tryparse(::Type{T}, s::Union{Missing, Nothing}) where T<:Number = s


### PR DESCRIPTION
This allows parse and tryparse to allow Nothing and Missing types as inputs, returning the original input. 
closes https://github.com/JuliaData/Missings.jl/issues/61